### PR TITLE
Jc/resource reporter 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# chef-reporting
+
+## Overview
+
+This gem contains an event handler for Chef that allows older (< 11.6.0)
+version of chef to publish reporting information to Opscode Hosted Chef
+or Opscode Private Chef.
+
+## Manual Configuration
+
+### Loading the gem
+The `chef-reporting` gem is required to be loaded.  The easiest way is
+to use the `chef_gem` resource to install the gem.
+
+
+```ruby
+chef_gem "chef-reporting" do
+  action :install
+end
+```
+
+### Enabling the gem in `client.rb`
+
+The Event Handler should be configured in your `client.rb` to enable the
+handler.
+
+```ruby
+begin
+  require chef_reporting
+  start_handlers << Chef::Reporting::StartHandler.new()
+rescue LoadError
+  Chef::Log.warn "Failed to load #{lib}. This should be resolved after a chef run."
+end
+```
+
+## Configuration using the `chef-client` cookbook
+The `chef-client` cookbook is able to automatically install and
+configure gems used for start and event handlers:
+
+```ruby
+node.set['chef_client']['load_gems']['chef-reporting'] = {
+    :require_name => 'chef_reporting',
+    :action => :install
+}
+
+node.set['chef_client']['start_handlers'] = [
+    {
+        :class => "Chef::Reporting::StartHandler",
+        :arguments => []
+    }
+]
+include_recipe "chef-client::config"
+```
+
+## Licence and Author
+
+Chef Reporting - A client library for Chef Reporting features
+
+|                      |                                          |
+|:---------------------|:-----------------------------------------|
+| **Author:**          | James Casey (<james@opscode.com>)
+| **Copyright:**       | Copyright (c) 2012-2013 Opscode, Inc.
+| **License:**         | Apache License, Version 2.0

--- a/README.md
+++ b/README.md
@@ -6,34 +6,11 @@ This gem contains an event handler for Chef that allows older (< 11.6.0)
 version of chef to publish reporting information to Opscode Hosted Chef
 or Opscode Private Chef.
 
-## Manual Configuration
+## Configuration
 
-### Loading the gem
-The `chef-reporting` gem is required to be loaded.  The easiest way is
-to use the `chef_gem` resource to install the gem.
+There are 2 different methods on how to install the handler:
 
-
-```ruby
-chef_gem "chef-reporting" do
-  action :install
-end
-```
-
-### Enabling the gem in `client.rb`
-
-The Event Handler should be configured in your `client.rb` to enable the
-handler.
-
-```ruby
-begin
-  require chef_reporting
-  start_handlers << Chef::Reporting::StartHandler.new()
-rescue LoadError
-  Chef::Log.warn "Failed to load #{lib}. This should be resolved after a chef run."
-end
-```
-
-## Configuration using the `chef-client` cookbook
+### Option A - Configuration using the `chef-client` cookbook
 The `chef-client` cookbook is able to automatically install and
 configure gems used for start and event handlers:
 
@@ -51,6 +28,38 @@ node.set['chef_client']['start_handlers'] = [
 ]
 include_recipe "chef-client::config"
 ```
+
+### Option B - Direct Configuration by modifying client.rb
+You can also do the same configuration e.g. as part of your bootstrap
+process if you want to have the first client run on the host send data
+to reporting.
+
+#### Loading the gem
+The `chef-reporting` gem is required to be loaded. You can do this is a
+`gem install` before running Chef if you want the first client run to
+report or else use the `chef_gem` resource to install the gem on first
+chef-client run.
+
+```ruby
+chef_gem "chef-reporting" do
+  action :install
+end
+```
+
+#### Loading the gem and configuring the event handler in `client.rb`
+
+The Event Handler should be configured in your `client.rb` to enable the
+handler.  Copy the following block to the top of your `client.rb`.
+
+```ruby
+begin
+  require chef_reporting
+  start_handlers << Chef::Reporting::StartHandler.new()
+rescue LoadError
+  Chef::Log.warn "Failed to load #{lib}. This should be resolved after a chef run."
+end
+```
+
 
 ## Licence and Author
 

--- a/chef-reporting.gemspec
+++ b/chef-reporting.gemspec
@@ -1,19 +1,20 @@
-$:.unshift(File.dirname(__FILE__) + '/lib')
-require 'chef/version'
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'chef_reporting/version'
 
-Gem::Specification.new do |s|
-  s.name = 'chef-reporting'
-  s.version = "0.1.0"
-  s.platform = Gem::Platform::RUBY
-  s.extra_rdoc_files = ["README.md", "LICENSE" ]
-  s.summary = "Plugin to enable reporting for Chef"
-  s.description = s.summary
-  s.author = "James Casey"
-  s.email = "james@opscode.com"
-  s.homepage = "http://docs.opscode.com"
+Gem::Specification.new do |gem|
+  gem.name = 'chef-reporting'
+  gem.version = Chef::Reporting::VERSION
+  gem.license = "Apache 2.0"
+  gem.author = "Opscode"
+  gem.email = "info@opscode.com"
+  gem.description = "Backport of Chef Reporting handler for Chef < 11.6.0"
+  gem.summary = gem.description
+  gem.homepage = "https://github.com/opscode/chef-reporting"
+
+  gem.files = `git ls-files`.split($/)
+  gem.require_paths = ["lib"]
 
   # TODO - Can we relax this dependency
-  s.add_dependency "chef", ">= 11.4.0"
-  s.files = %w(LICENSE README.md) + Dir.glob("lib/**/*")
-  s.require_paths = ["lib"]
+  gem.add_dependency "chef", ">= 11.0.0"
 end

--- a/lib/chef_reporting/resource_reporter.rb
+++ b/lib/chef_reporting/resource_reporter.rb
@@ -3,7 +3,7 @@
 # Author:: Prajakta Purohit (prajakta@opscode.com>)
 # Auther:: Tyler Cloke (<tyler@opscode.com>)
 #
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-13 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef_reporting/resource_reporter.rb
+++ b/lib/chef_reporting/resource_reporter.rb
@@ -100,7 +100,7 @@ class Chef
         begin
           @run_id = uuid
         rescue LoadError
-          Chef::Log.debug("Can't load uuidtools - disabling resource_reporter")
+          Chef::Log.debug("Can't load SecureRandom - disabling resource_reporter")
           @reporting_enabled = false
         end
         @rest_client = rest_client

--- a/lib/chef_reporting/resource_reporter.rb
+++ b/lib/chef_reporting/resource_reporter.rb
@@ -33,7 +33,7 @@ class Chef
 
         def self.new_with_current_state(new_resource, action, current_resource)
           report = new
-            report.new_resource = new_resource
+          report.new_resource = new_resource
           report.action = action
           report.current_resource = current_resource
           report
@@ -66,7 +66,6 @@ class Chef
           as_hash["cookbook_name"] = new_resource.cookbook_name
           as_hash["cookbook_version"] = new_resource.cookbook_version.version
           as_hash
-
         end
 
         def finish
@@ -76,14 +75,16 @@ class Chef
         def success?
           !self.exception
         end
-      end
+
+      end # End class ResouceReport
 
       attr_reader :updated_resources
       attr_reader :status
       attr_reader :exception
       attr_reader :run_id
       attr_reader :error_descriptions
-      attr_reader :summary_only
+
+      PROTOCOL_VERSION = '0.1.0'
 
       def initialize(rest_client)
         if Chef::Config[:enable_reporting] && !Chef::Config[:why_run]
@@ -96,37 +97,60 @@ class Chef
         @pending_update  = nil
         @status = "success"
         @exception = nil
-        @run_id = nil
+        begin
+          @run_id = uuid
+        rescue LoadError
+          Chef::Log.debug("Can't load uuidtools - disabling resource_reporter")
+          @reporting_enabled = false
+        end
         @rest_client = rest_client
-        @node = nil
         @error_descriptions = {}
-        @summary_only = true
       end
 
-      def node_load_completed(node, expanded_run_list_with_versions, config)
-        @node = node
+      def run_started(run_status)
+        @run_status = run_status
+
         if reporting_enabled?
           begin
-            resource_history_url = "reports/nodes/#{node.name}/runs"
-            server_response = @rest_client.post_rest(resource_history_url, {:action => :begin})
-            run_uri = URI.parse(server_response["uri"])
-            @run_id = ::File.basename(run_uri.path)
-            Chef::Log.info("Chef server generated run history id: #{@run_id}")
-            @summary_only = server_response["summary_only"]
+            resource_history_url = "reports/nodes/#{node_name}/runs"
+            server_response = @rest_client.post_rest(resource_history_url, {:action => :start, :run_id => @run_id,
+                                                                            :start_time => start_time.to_s}, headers)
           rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
-            if !e.response || e.response.code.to_s != "404"
-              if Chef::Config[:enable_reporting_url_fatals]
-                Chef::Log.error("Received exception #{"(" + e.response.code + ") " if e.response.code}attempting to generate run history id (URL Path: #{resource_history_url}), and enable_reporting_url_fatals is set, aborting run.")
-                raise
-              else
-                Chef::Log.info("Received exception #{"(" + e.response.code + ") " if e.response.code}attempting to generate run history id (URL Path: #{resource_history_url}), disabling reporting for this run.")
-              end
-            else
-              Chef::Log.debug("Received 404 attempting to generate run history id (URL Path: #{resource_history_url}), assuming feature is not supported on server.")
-            end
-            @reporting_enabled = false
+            handle_error_starting_run(e, resource_history_url)
           end
         end
+      end
+
+      def handle_error_starting_run(e, url)
+        message = "Reporting error starting run. URL: #{url} "
+        code = if e.response.code
+                 e.response.code.to_s
+               else
+                 "Exception Code Empty"
+               end
+
+        if !e.response || (code != "404" && code != "406")
+          exception = "Exception: #{code} "
+          if Chef::Config[:enable_reporting_url_fatals]
+            reporting_status = "Reporting fatals enabled. Aborting run. "
+            Chef::Log.error(message + exception + reporting_status)
+            raise
+          else
+            reporting_status = "Disabling reporting for run."
+            Chef::Log.info(message + exception + reporting_status)
+          end
+        else
+          reason = "Received #{code}. "
+          if code == "406"
+            reporting_status = "Client version not supported. Please update the client. Disabling reporting for run."
+            Chef::Log.info(message + reason + reporting_status)
+          else
+            reporting_status = "Disabling reporting for run."
+            Chef::Log.debug(message + reason + reporting_status)
+          end
+        end
+
+        @reporting_enabled = false
       end
 
       def resource_current_state_loaded(new_resource, action, current_resource)
@@ -175,29 +199,25 @@ class Chef
       def run_failed(exception)
         @exception = exception
         @status = "failure"
-        post_reporting_data
+        # If we failed before we received the run_started callback, there's not much we can do
+        # in terms of reporting
+        if @run_status
+          post_reporting_data
+        end
       end
 
       def post_reporting_data
         if reporting_enabled?
           run_data = prepare_run_data
-          resource_history_url = "reports/nodes/#{@node.name}/runs/#{@run_id}"
+          resource_history_url = "reports/nodes/#{node_name}/runs/#{@run_id}"
           Chef::Log.info("Sending resource update report (run-id: #{@run_id})")
           Chef::Log.debug run_data.inspect
           compressed_data = encode_gzip(run_data.to_json)
           begin
-            #if summary only is enabled send the uncompressed run_data excluding the run_data["resources"] and some additional metrics.
-            if @summary_only
-              run_data = report_summary(run_data, compressed_data)
-              Chef::Log.info("run_data_summary: #{run_data}")
-              @rest_client.post_rest(resource_history_url, run_data)
-            else
-              Chef::Log.debug("Sending compressed run data...")
-              # Since we're posting compressed data we can not directly call
-              # post_rest which expects JSON
-              reporting_url = @rest_client.create_url(resource_history_url)
-              @rest_client.raw_http_request(:POST, reporting_url, {'Content-Encoding' => 'gzip'}, compressed_data)
-            end
+            Chef::Log.debug("Sending compressed run data...")
+            # Since we're posting compressed data we can not directly call post_rest which expects JSON
+            reporting_url = @rest_client.create_url(resource_history_url)
+            @rest_client.raw_http_request(:POST, reporting_url, headers({'Content-Encoding' => 'gzip'}), compressed_data)
           rescue Net::HTTPServerException => e
             if e.response.code.to_s == "400"
               Chef::FileCache.store("failed-reporting-data.json", Chef::JSONCompat.to_json_pretty(run_data), 0640)
@@ -211,6 +231,23 @@ class Chef
         end
       end
 
+      def headers(additional_headers = {})
+        options = {'X-Ops-Reporting-Protocol-Version' => PROTOCOL_VERSION}
+        options.merge(additional_headers)
+      end
+
+      def node_name
+        @run_status.node.name
+      end
+
+      def start_time
+        @run_status.start_time
+      end
+
+      def end_time
+        @run_status.end_time
+      end
+
       def prepare_run_data
         run_data = {}
         run_data["action"] = "end"
@@ -218,9 +255,11 @@ class Chef
           resource_record.for_json
         end
         run_data["status"] = @status
-        run_data["run_list"] = @node.run_list.to_json
+        run_data["run_list"] = @run_status.node.run_list.to_json
         run_data["total_res_count"] = @total_res_count.to_s
         run_data["data"] = {}
+        run_data["start_time"] = start_time.to_s
+        run_data["end_time"] = end_time.to_s
 
         if exception
           exception_data = {}
@@ -230,13 +269,6 @@ class Chef
           exception_data["description"] =  @error_descriptions
           run_data["data"]["exception"] = exception_data
         end
-        run_data
-      end
-
-      def report_summary(run_data, compressed_data)
-        run_data["updated_res_count"] = updated_resources.count.to_s
-        run_data["post_size"] = compressed_data.bytesize.to_s
-        run_data["resources"] = []
         run_data
       end
 
@@ -275,6 +307,14 @@ class Chef
         end
       end
 
+      def uuid
+        require 'securerandom'
+        # Ruby 1.8.7 does not have SecureRandom::uuid, so copy the 1.9.2 impl here
+        ary = SecureRandom.random_bytes(16).unpack("NnnnnN")
+        ary[2] = (ary[2] & 0x0fff) | 0x4000
+        ary[3] = (ary[3] & 0x3fff) | 0x8000
+        "%08x-%04x-%04x-%04x-%04x%08x" % ary
+      end
     end
   end
 end

--- a/lib/chef_reporting/start_handler.rb
+++ b/lib/chef_reporting/start_handler.rb
@@ -1,5 +1,4 @@
 #
-# Author:: James Casey (<james@opscode.com>)
 # Copyright:: Copyright (c) 2013 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #

--- a/lib/chef_reporting/version.rb
+++ b/lib/chef_reporting/version.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,5 +15,9 @@
 # limitations under the License.
 #
 
-require 'chef_reporting/start_handler'
-require 'chef_reporting/resource_reporter'
+module Chef
+  module Reporting
+    VERSION = "0.1.0"
+  end
+end
+


### PR DESCRIPTION
A version of the Resource Reporter for use with chef-client < 11.6.0 such that they can use the new reporting protocol supported on Opscode Hosted Chef.

Contains a start handler which will load and initialize the event handler.
